### PR TITLE
kea: use absolute paths for kea binaries

### DIFF
--- a/kea/run.sh
+++ b/kea/run.sh
@@ -26,8 +26,8 @@ echo "SERVER_ID=${SERVER_ID}"
     /config/kea-dhcp4.json > /work/kea-dhcp4.json
 )
 
-kea-ctrl-agent -c /app/kea-ctrl-agent.json &
+/usr/sbin/kea-ctrl-agent -c /app/kea-ctrl-agent.json &
 /app/stork-agent &
 /app/healthzd &
 
-kea-dhcp4 -c /work/kea-dhcp4.json
+/usr/sbin/kea-dhcp4 -c /work/kea-dhcp4.json


### PR DESCRIPTION
stork-agent v2.3.2 detects the Kea binary path by extracting the directory prefix from the process cmdline (regex match[1]). When bare names are used, match[1] is empty, and the path is resolved against the process CWD, which is /work because run.sh does `cd /work`. This produces /work/kea-dhcp4, which doesn't exist.

Using absolute paths makes match[1] = "/usr/sbin/" so stork resolves /usr/sbin/kea-dhcp4 correctly.